### PR TITLE
Ignore Generic.Arrays.DisallowShortArraySyntax 

### DIFF
--- a/NeutronRuleset/ruleset.xml
+++ b/NeutronRuleset/ruleset.xml
@@ -95,4 +95,7 @@
 	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_var_export">
 		<severity>0</severity>
 	</rule>
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<severity>0</severity>
+	</rule>
 </ruleset>


### PR DESCRIPTION
It was added to WordPress-core in WPCS 2.2.0 for PHP 5.6 compatibility. We can safely ignore it.
